### PR TITLE
fix: anchor scroll

### DIFF
--- a/packages/vuepress/vuepress-theme-titanium/plugins/smoothScroll/enhanceApp.js
+++ b/packages/vuepress/vuepress-theme-titanium/plugins/smoothScroll/enhanceApp.js
@@ -34,11 +34,32 @@ module.exports = ({ Vue, options, router }) => {
           behavior: 'smooth'
         })
       }
+      window.onload = () => {
+        const element = document.getElementById(location.hash.slice(1))
+        if (element) {
+          element.scrollIntoView()
+        }
+      }
     } else {
       const html = document.querySelector('html')
       html.style.scrollBehavior = 'auto'
       window.scrollTo({ top: 0 })
       html.style.scrollBehavior = ''
+    }
+
+    if (location.hash) {
+      setTimeout(function() {
+        const element = document.getElementById(location.hash.slice(1))
+        if (element) {
+          element.scrollIntoView()
+        }
+      }, 250);
+    }
+    window.onload = () => {
+      const element = document.getElementById(location.hash.slice(1))
+      if (element) {
+        element.scrollIntoView()
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-docs/issues/

Sometimes `onLoad` is trigger and sometimes not. Catching that with the setTimeout. Not the best solution but it makes the anchor links and search work again!

**Test:**
* go to https://titaniumsdk.com/api/titanium/ui/window.html#extendedges
* click on `Titanium.UI.EXTEND_EDGE_BOTTOM`
* current page won't scroll to it
* navigate back and check if it scrolls to the correct anchor again

**Test2**
* search for `addMarker` and click the link
* check if it scrolls to the anchor
