### PR TITLE
feat(docs): fix menu links

### DIFF
--- a/packages/vuepress/vuepress-plugin-apidocs/components/EventList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/EventList.vue
@@ -5,8 +5,8 @@
     </h2>
 
     <div v-for="(event, index) in events" :key="event.name">
-      <div class="member-header">
-        <h3 :id="event.name.toLowerCase()">
+      <div class="member-header" :id="`${event.name.toLowerCase()}`">
+        <h3 :id="`events_${event.name.toLowerCase()}`">
           <a :href="`#${event.name.toLowerCase()}`" class="header-anchor">#</a> {{event.name}} <Badge v-if="event.deprecated" text="DEPRECATED" type="warn"/>
         </h3>
         <AvailabilityInfo :platforms="event.platforms"/>

--- a/packages/vuepress/vuepress-plugin-apidocs/components/MethodList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/MethodList.vue
@@ -5,8 +5,8 @@
     </h2>
 
     <div v-for="(method, index) in methods" :key="method.name">
-      <div class="member-header">
-        <h3 :id="method.name.toLowerCase()">
+      <div class="member-header" :id="`${method.name.toLowerCase()}`">
+        <h3 :id="`methods_${method.name.toLowerCase()}`">
           <a :href="`#${method.name.toLowerCase()}`" class="header-anchor">#</a> {{method.name}} <Badge v-if="method.deprecated" text="DEPRECATED" type="warn"/>
         </h3>
         <AvailabilityInfo :platforms="method.platforms"/>

--- a/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
@@ -5,8 +5,9 @@
     </h2>
 
     <div v-for="(property, index) in properties" :key="property.name">
-      <div class="member-header">
+      <div class="member-header" :id="`${property.name.toLowerCase()}`">
         <h3 :id="property.name.toLowerCase()">
+        <h3 :id="`properties_${property.name.toLowerCase()}`">
           <a :href="`#${property.name.toLowerCase()}`" class="header-anchor">#</a> {{property.name}} <Badge v-if="property.permission === 'read-only'" text="READONLY" type="light"/><Badge v-if="property.availability === 'creation'" text="CREATION ONLY" type="info"/><Badge v-if="property.deprecated" text="DEPRECATED" type="warn"/>
         </h3>
         <AvailabilityInfo :platforms="property.platforms"/>

--- a/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
+++ b/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
@@ -108,7 +108,7 @@ class MetadataProcessor {
       headers.push({
         level: 3,
         title: memberMetadata.name,
-        slug: memberMetadata.name.toLowerCase()
+        slug: memberType + "_" + memberMetadata.name.toLowerCase()
       })
     })
     if (headers.length) {


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-docs/issues/45

I've added `methods_...` to the links in the side-menu so they are unique. If you go to https://titaniumsdk.com/api/modules/map/view.html and click on `userLocation` (event) it will scroll to `userLocation` (property). 

To keep all existing links I've moved the unprefixed ID to the div above it. So you can still use `/api/titanium/ui.html#createactivityindicator` and `/api/titanium/ui.html#methods_createactivityindicator` (unique)