### PR TITLE
feat(docs): show inherit elements

### DIFF
--- a/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
+++ b/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
@@ -58,9 +58,9 @@ class MetadataProcessor {
 
   filterInheritedMembers (metadata) {
     const filterInherited = member => {
-      if (member.inherits && member.inherits !== metadata.name) {
-        return false
-      }
+      // if (member.inherits && member.inherits !== metadata.name) {
+      //   return false
+      // }
 
       return true
     }


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-docs/issues/75 !

Currently the extended methods aren't visible in the docs (left side), with this PR it will add all of them:

![Screenshot_20220915_150040](https://user-images.githubusercontent.com/4334997/190410233-ee23afa9-6d20-45f1-93ec-595b573725a3.png)

https://titaniumsdk.com/api/titanium/ui/scrollview.html

I just uncomment the function that excluded them. In the future it would be good to add a special class to them and show that they are inherited.

