### PR TITLE
fix: h3 copy&paste error

### DIFF
--- a/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
@@ -6,7 +6,6 @@
 
     <div v-for="(property, index) in properties" :key="property.name">
       <div class="member-header" :id="`${property.name.toLowerCase()}`">
-        <h3 :id="property.name.toLowerCase()">
         <h3 :id="`properties_${property.name.toLowerCase()}`">
           <a :href="`#${property.name.toLowerCase()}`" class="header-anchor">#</a> {{property.name}} <Badge v-if="property.permission === 'read-only'" text="READONLY" type="light"/><Badge v-if="property.availability === 'creation'" text="CREATION ONLY" type="info"/><Badge v-if="property.deprecated" text="DEPRECATED" type="warn"/>
         </h3>


### PR DESCRIPTION
Did a copy&paste error in the properties h3 in the last commit:

![Screenshot_20221025_083650](https://user-images.githubusercontent.com/4334997/197700277-542a3a9e-68a5-40db-88f1-2de179ccdbac.png)

the old H3 line shouldn't be there! It's complaining at the moment that a closing h3 is missing