### PR TITLE
feat: more search results

### DIFF
--- a/packages/vuepress/vuepress-theme-titanium/index.js
+++ b/packages/vuepress/vuepress-theme-titanium/index.js
@@ -18,7 +18,7 @@ module.exports = (options, ctx) => ({
     }
   },
   plugins: [
-    ['@vuepress/search', { searchMaxSuggestions: 10 }],
+    ['@vuepress/search', { searchMaxSuggestions: 30 }],
     '@vuepress/nprogress',
     ['container', { type: 'tip' }],
     ['container', { type: 'warning' }],

--- a/packages/vuepress/vuepress-theme-titanium/styles/theme.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/theme.styl
@@ -48,7 +48,10 @@ body
   background-color $white
   box-sizing border-box
   border-bottom 1px solid $borderColor
-
+  .suggestions
+    max-height 400px
+    overflow-y auto
+    
 .sidebar-mask
   position fixed
   z-index 9


### PR DESCRIPTION
display more search results (30 instead of 10) but keeping the max. height of the search results the same height (with scrolling)

![Screenshot_20230208_155130](https://user-images.githubusercontent.com/4334997/217565252-2a6f6830-7610-40a2-a136-68a403a0049a.png)
