### PR TITLE
fix: docgen interfaces

### DIFF
--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -21,7 +21,13 @@ const skipApis = [
 // List of modules that need to be generated as an interface instead of a namespace.
 const forcedInterfaces = [
 	'Titanium.Android.R',
-	'Titanium.App.iOS.UserDefaults'
+	'Titanium.App.iOS.UserDefaults',
+	'Titanium.Media.Item',
+	'Titanium.Calendar.Attendee',
+	'Titanium.Calendar.Reminder',
+	'Titanium.Calendar.RecurrenceRule',
+	'Titanium.Platform.DisplayCaps',
+	'Titanium.XML.DocumentType'
 ];
 
 const eventsMethods = [


### PR DESCRIPTION
Had to change some namespaces to interfaces so https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64580 tests will succeed. 

Errors before e.g.
```
'Titanium.Calendar.RecurrenceRule' refers to a value, but is being used as a type here. Did you mean 'typeof Titanium.Calendar.RecurrenceRule'?
```