### PR TITLE
feat: show constants again

### DIFF
--- a/packages/vuepress/vuepress-plugin-apidocs/components/ConstantList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/ConstantList.vue
@@ -5,8 +5,8 @@
     </h2>
 
     <div v-for="(constant, index) in constants" :key="constant.name">
-      <div class="member-header">
-        <h4 :id="constant.name.toLowerCase()">
+      <div class="member-header" :id="`${constant.name.toLowerCase()}`">
+        <h4 :id="`constants_${constant.name.toLowerCase()}`">
           <a :href="`#${constant.name.toLowerCase()}`" class="header-anchor">#</a> {{constant.name}} <Badge v-if="constant.deprecated" text="DEPRECATED" type="warn"/>
         </h4>
         <AvailabilityInfo :platforms="constant.platforms"/>

--- a/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
+++ b/packages/vuepress/vuepress-plugin-apidocs/lib/metadata/processor.js
@@ -117,9 +117,7 @@ class MetadataProcessor {
         title: memberType.charAt(0).toUpperCase() + memberType.slice(1),
         slug: memberType
       })
-      if (memberType !== 'constants') {
-        this.additionalHeaders = this.additionalHeaders.concat(headers)
-      }
+      this.additionalHeaders = this.additionalHeaders.concat(headers)
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/tidev/titanium-docs/issues/44

Current constants menu is empty but items are in the page:
https://titaniumsdk.com/api/titanium/ui/android.html#constants
![Screenshot_20230401_170723](https://user-images.githubusercontent.com/4334997/229297356-ddec3bbf-c81c-4fdf-8333-59ce00c3c962.png)


With this PR the menu will be populated again:
![Screenshot_20230401_170633](https://user-images.githubusercontent.com/4334997/229297375-90389690-1ca6-4d28-aee7-6dc34074f856.png)
