### PR TITLE
fix 'Empty string passed to getElementById()'

### DIFF
--- a/packages/vuepress/vuepress-theme-titanium/plugins/smoothScroll/enhanceApp.js
+++ b/packages/vuepress/vuepress-theme-titanium/plugins/smoothScroll/enhanceApp.js
@@ -35,9 +35,11 @@ module.exports = ({ Vue, options, router }) => {
         })
       }
       window.onload = () => {
-        const element = document.getElementById(location.hash.slice(1))
-        if (element) {
-          element.scrollIntoView()
+        if (location.hash.slice(1) != "") {
+          const element = document.getElementById(location.hash.slice(1))
+          if (element) {
+            element.scrollIntoView()
+          }
         }
       }
     } else {
@@ -49,16 +51,20 @@ module.exports = ({ Vue, options, router }) => {
 
     if (location.hash) {
       setTimeout(function() {
-        const element = document.getElementById(location.hash.slice(1))
-        if (element) {
-          element.scrollIntoView()
+        if (location.hash.slice(1) != "") {
+          const element = document.getElementById(location.hash.slice(1))
+          if (element) {
+            element.scrollIntoView()
+          }
         }
       }, 250);
     }
     window.onload = () => {
-      const element = document.getElementById(location.hash.slice(1))
-      if (element) {
-        element.scrollIntoView()
+      if (location.hash.slice(1) != "") {
+        const element = document.getElementById(location.hash.slice(1))
+        if (element) {
+          element.scrollIntoView()
+        }
       }
     }
   }


### PR DESCRIPTION
Currently pages without a hashtag show a warning:
`Empty string passed to getElementById().`

This fix will check for empty hashtags