### PR TITLE
fix: properly handle promise generics

### DIFF
--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -175,7 +175,9 @@ class DocsParser {
 			// skip bundled documentation for modules and Node.js shims
 			return;
 		}
-		const namespaceParts = typeInfo.name.split('.');
+		// Handle generic types by extracting the base type name before the first '<'
+		const typeName = typeInfo.name.split('<')[0];
+		const namespaceParts = typeName.split('.');
 		namespaceParts.pop();
 		if (skipApis.includes(typeInfo.name)) {
 			return;
@@ -622,7 +624,17 @@ class GlobalTemplateWriter {
 
 		if (Array.isArray(docType)) {
 			const normalizedTypes = docType.map(typeName => this.normalizeType(typeName));
-			return normalizedTypes.includes('any') ? 'any' : normalizedTypes.join(' | ');
+			if (normalizedTypes.includes('any')) {
+				return 'any';
+			}
+			// Parenthesize function types in unions to avoid TypeScript syntax errors
+			const parenthesizedTypes = normalizedTypes.map(type => {
+				if (type.includes(') => ')) {
+					return `(${type})`;
+				}
+				return type;
+			});
+			return parenthesizedTypes.join(' | ');
 		}
 
 		const lessThanIndex = docType.indexOf('<');
@@ -649,6 +661,9 @@ class GlobalTemplateWriter {
 				}
 			} else if (baseType === 'Dictionary') {
 				return `Dictionary<${subType}>`;
+			} else if (baseType === 'Promise') {
+				// Use standard Promise<T> generic syntax
+				return `Promise<${subTypes.join(', ')}>`;
 			}
 		}
 


### PR DESCRIPTION
This pull request improves the TypeScript code generation in the documentation generator by enhancing type handling, especially for generics and union types. The changes ensure that generated TypeScript code is more accurate and syntactically correct, particularly when dealing with complex types like generics, union types involving functions, and Promises.

Type handling improvements:

* Updated `DocsParser` to correctly extract the base type name before generics (e.g., strips `<T>` from `Type<T>`) when splitting namespaces, preventing issues with generic type names.
* Modified `GlobalTemplateWriter` to parenthesize function types within union types, preventing TypeScript syntax errors (e.g., outputs `(a: string) => void | number` as `((a: string) => void) | number`).
* Enhanced generic type support in `GlobalTemplateWriter` by adding explicit handling for `Promise<T>` types, ensuring standard TypeScript generic syntax is used for Promises.